### PR TITLE
Update 1196-metadata.yaml

### DIFF
--- a/1196-metadata.yaml
+++ b/1196-metadata.yaml
@@ -21,14 +21,14 @@ creator:
   family: Cairns
 editor:
  -
-  given: Stephen
-  family: Cairns
-  email: cairnss@si.edu
- -
   orcid: 0000-0001-8259-3783
   given: Bert
   family: Hoeksema
   email: bert.hoeksema@naturalis.nl
+  -
+  given: Stephen
+  family: Cairns
+  email: cairnss@si.edu
 contributor:
  -
   country: US


### PR DESCRIPTION
The order of Hoeksema and Cairns is wrong; it now follows https://www.marinespecies.org/scleractinia/